### PR TITLE
Let users access their profile in couchdb if autosync on

### DIFF
--- a/conf/couch.ini
+++ b/conf/couch.ini
@@ -7,3 +7,6 @@ credentials = true
 headers	= accept, authorization, content-type, origin, referer
 methods	= GET, PUT, POST, HEAD, DELETE
 origins = https://__DOMAIN__
+
+[couchdb]
+users_db_security_editable = true

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "Store all kinds of data with an extremely customizable interface.",
         "fr": "Stockez tous types de données avec une interface complètement customizable."
     },
-    "version": "1.5.11~ynh2",
+    "version": "1.5.16~ynh2",
     "url": "https://squeak.eauchat.org/dato",
     "upstream": {
         "license": "AGPL-3.0-or-later",

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -5,7 +5,7 @@
 #=================================================
 
 # dependencies used by the app
-pkg_dependencies="curl"
+pkg_dependencies="curl jq"
 
 # nodejs version
 nodejs_version=12

--- a/scripts/install
+++ b/scripts/install
@@ -174,19 +174,33 @@ if [[ $autosynchronize == true ]]; then
 	couch_pw_url=$(echo "$couch_url" | sed -En "s+^https?://+https://$couch_admin_name:$couch_admin_password@+p")
 
 	# add admin user to couch users database
-	curlResult=$(curl -X PUT "$couch_pw_url/_users/org.couchdb.user:$couch_datoadmin_name" \
+	addDatoAdmin_curlResult=$(curl -X PUT "$couch_pw_url/_users/org.couchdb.user:$couch_datoadmin_name" \
      -H "Accept: application/json" \
      -H "Content-Type: application/json" \
      -d "{\"name\": \"$couch_datoadmin_name\", \"password\": \"$couch_datoadmin_password\", \"roles\": [\"dato-admin\"], \"type\": \"user\"}" 2> /dev/null)
 
 	# display error message if there was an error creating dato admin user in couch
-	if [[ $curlResult != '{"ok":true,'* ]]; then
+	if [[ $addDatoAdmin_curlResult != '{"ok":true,'* ]]; then
 		ynh_print_err --message="There was an error creating the dato admin user for in couch. You will probably have to do it manually (check the last section of this page for instructions: https://squeak.eauchat.org/apps/dato/?setups)."
 		ynh_print_err --message="Here is the error message from couchdb:"
-		ynh_print_err --message="$curlResult"
+		ynh_print_err --message="$addDatoAdmin_curlResult"
 		ynh_print_err --message="Please make sure that your couchdb instance is accessible from the url you provided, with a proper SSL certificate (not a self-signed one), otherwise you will not be able to login to dato!"
-		ynh_print_err --message="$curlResult"
 	fi
+
+		# modify _users db _security document
+		usersSecDoc=$(curl -X GET "$couch_pw_url/_users/_security")
+		usersSecDocModified=$(echo $usersSecDoc | jq '.members.roles += ["dato", "dato-admin"]')
+		usersSecDocChange_curlResult=$(curl -X PUT "$couch_pw_url/_users/_security" \
+	     -H "Accept: application/json" \
+	     -H "Content-Type: application/json" \
+	     -d "$usersSecDocModified" 2> /dev/null)
+
+		 # display error message if there was an error modifying _users db _security document
+	 	if [[ $usersSecDocChange_curlResult != '{"ok":true,'* ]]; then
+	 		ynh_print_err --message="There was an error enabling dato users to access their user profile in couch. You will have to do it manually (check the 'Configure couchdb so that it accepts requests from dato' section in the following page for instructions: https://squeak.eauchat.org/apps/dato/?setups)."
+	 		ynh_print_err --message="Here is the error message from couchdb:"
+	 		ynh_print_err --message="$usersSecDocChange_curlResult"
+	 	fi
 
 fi
 


### PR DESCRIPTION
Recent versions of couchdb block users from access their profile in the "_users" database, which is necessary for users to login to dato. This PR makes dato modify the preferences of couchdb accordingly if autosync is enabled.
